### PR TITLE
Add noise reduction MCP tools

### DIFF
--- a/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
@@ -168,6 +168,29 @@ public class RadioTools
         return ok ? $"Mode set to {mode.ToUpper()}" : "Failed to set mode.";
     }
 
+    [McpServerTool, Description("Get the current receiver passband filter bounds (low/high Hz) for the active slice.")]
+    public string GetFilter()
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        var filter = _radioManager.GetFilter();
+        if (filter == null)
+            return "No active slice.";
+
+        return JsonSerializer.Serialize(new { FilterLow = filter.Value.Low, FilterHigh = filter.Value.High }, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool, Description("Set the receiver passband filter bounds in Hz. Example: low=200, high=1000 for narrow CW.")]
+    public string SetFilter(int low, int high)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        bool ok = _radioManager.SetFilter(low, high);
+        return ok ? $"Filter set to {low}-{high} Hz" : "No active slice.";
+    }
+
     [McpServerTool, Description("Get real-time meter readings from the radio including S-meter, SWR, forward/reflected power, PA temperature, voltage, mic level, ALC, and compression. Values update continuously while connected.")]
     public string GetMeters()
     {
@@ -178,11 +201,62 @@ public class RadioTools
         return JsonSerializer.Serialize(meters, new JsonSerializerOptions { WriteIndented = true });
     }
 
+    [McpServerTool, Description("Set RIT (Receiver Incremental Tuning). Enable/disable and set offset in Hz.")]
+    public string SetRit(bool? enabled = null, int? offsetHz = null)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+        bool ok = _radioManager.SetRit(enabled, offsetHz);
+        return ok ? $"RIT set: enabled={enabled?.ToString() ?? "unchanged"}, offset={offsetHz?.ToString() ?? "unchanged"} Hz" : "No active slice.";
+    }
+
+    [McpServerTool, Description("Set XIT (Transmitter Incremental Tuning). Enable/disable and set offset in Hz.")]
+    public string SetXit(bool? enabled = null, int? offsetHz = null)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+        bool ok = _radioManager.SetXit(enabled, offsetHz);
+        return ok ? $"XIT set: enabled={enabled?.ToString() ?? "unchanged"}, offset={offsetHz?.ToString() ?? "unchanged"} Hz" : "No active slice.";
+    }
+
+    [McpServerTool, Description("List all receiver slices with their configuration: frequency, mode, filter, antenna, AGC, noise reduction, and more.")]
+    public string ListSlices()
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        var slices = _radioManager.ListSlices();
+        if (slices.Count == 0)
+            return "No slices available.";
+
+        return JsonSerializer.Serialize(slices, new JsonSerializerOptions { WriteIndented = true });
+    }
+
     [McpServerTool, Description("Set CW profile values in one operation. All params optional: wpm, pitch, breakIn, iambic.")]
     public string SetCwProfile(int? wpm = null, int? pitch = null, bool? breakIn = null, string? iambic = null)
     {
         var (success, message) = _radioManager.SetCwProfile(wpm, pitch, breakIn, iambic);
         return success ? message : $"Failed: {message}";
+    }
+
+    [McpServerTool, Description("Get noise reduction settings (NR, NB, ANF, WNB) for the active slice.")]
+    public string GetNoiseReduction()
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        var nr = _radioManager.GetNoiseReduction();
+        return nr == null ? "No active slice." : JsonSerializer.Serialize(nr, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool, Description("Set noise reduction on the active slice. All params optional: nrOn, nrLevel, nbOn, nbLevel, anfOn, anfLevel, wnbOn, wnbLevel.")]
+    public string SetNoiseReduction(bool? nrOn = null, int? nrLevel = null, bool? nbOn = null, int? nbLevel = null, bool? anfOn = null, int? anfLevel = null, bool? wnbOn = null, int? wnbLevel = null)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        bool ok = _radioManager.SetNoiseReduction(nrOn, nrLevel, nbOn, nbLevel, anfOn, anfLevel, wnbOn, wnbLevel);
+        return ok ? "Noise reduction settings updated." : "No active slice.";
     }
 
     private static DateTime? MaxTimestamp(DateTime? a, DateTime? b)

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -136,6 +136,39 @@ public class RadioManager : IDisposable
         return true;
     }
 
+    public (int Low, int High)? GetFilter()
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return null;
+        return (slice.FilterLow, slice.FilterHigh);
+    }
+
+    public bool SetFilter(int low, int high)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        slice.UpdateFilter(low, high);
+        return true;
+    }
+
+    public bool SetRit(bool? enabled, int? offsetHz)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        if (enabled.HasValue) slice.RITOn = enabled.Value;
+        if (offsetHz.HasValue) slice.RITFreq = offsetHz.Value;
+        return true;
+    }
+
+    public bool SetXit(bool? enabled, int? offsetHz)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        if (enabled.HasValue) slice.XITOn = enabled.Value;
+        if (offsetHz.HasValue) slice.XITFreq = offsetHz.Value;
+        return true;
+    }
+
     public bool SetActiveSlice(int sliceIndex)
     {
         var radio = _radio;
@@ -225,6 +258,66 @@ public class RadioManager : IDisposable
         }
 
         return false;
+    }
+
+    public List<object> ListSlices()
+    {
+        var radio = _radio;
+        if (radio == null || !radio.Connected) return [];
+
+        return radio.SliceList.Select(s => (object)new
+        {
+            s.Index,
+            s.Letter,
+            s.Active,
+            FrequencyMHz = s.Freq,
+            Mode = s.DemodMode,
+            s.FilterLow,
+            s.FilterHigh,
+            s.DAXChannel,
+            s.RXAnt,
+            s.TXAnt,
+            s.AGCMode,
+            s.AudioGain,
+            s.AudioPan,
+            s.Mute,
+            s.NROn,
+            s.NBOn,
+            s.ANFOn,
+            s.IsTransmitSlice,
+            s.RITOn,
+            s.RITFreq,
+            s.XITOn,
+            s.XITFreq
+        }).ToList();
+    }
+
+    public bool SetNoiseReduction(bool? nrOn = null, int? nrLevel = null, bool? nbOn = null, int? nbLevel = null, bool? anfOn = null, int? anfLevel = null, bool? wnbOn = null, int? wnbLevel = null)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        if (nrOn.HasValue) slice.NROn = nrOn.Value;
+        if (nrLevel.HasValue) slice.NRLevel = nrLevel.Value;
+        if (nbOn.HasValue) slice.NBOn = nbOn.Value;
+        if (nbLevel.HasValue) slice.NBLevel = nbLevel.Value;
+        if (anfOn.HasValue) slice.ANFOn = anfOn.Value;
+        if (anfLevel.HasValue) slice.ANFLevel = anfLevel.Value;
+        if (wnbOn.HasValue) slice.WNBOn = wnbOn.Value;
+        if (wnbLevel.HasValue) slice.WNBLevel = wnbLevel.Value;
+        return true;
+    }
+
+    public object? GetNoiseReduction()
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return null;
+        return new
+        {
+            NR = new { slice.NROn, slice.NRLevel },
+            NB = new { slice.NBOn, slice.NBLevel },
+            ANF = new { slice.ANFOn, slice.ANFLevel },
+            WNB = new { slice.WNBOn, slice.WNBLevel }
+        };
     }
 
     public Dictionary<string, object> GetMeters()


### PR DESCRIPTION
## Summary
- Add `GetNoiseReduction` and `SetNoiseReduction` methods to `RadioManager` for controlling NR, NB, ANF, and WNB on the active slice
- Add corresponding MCP tool endpoints in `RadioTools` so Claude can read and adjust noise reduction settings
- All parameters are optional, allowing granular control of individual settings

Closes #8

## Test plan
- [ ] Connect to radio and call `GetNoiseReduction` to verify current settings are returned
- [ ] Call `SetNoiseReduction` with individual params (e.g., `nrOn=true`, `nrLevel=50`) and verify changes apply
- [ ] Verify error handling when no radio connected or no active slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)