### PR TITLE
Add get_filter and set_filter MCP tools

### DIFF
--- a/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
@@ -168,6 +168,29 @@ public class RadioTools
         return ok ? $"Mode set to {mode.ToUpper()}" : "Failed to set mode.";
     }
 
+    [McpServerTool, Description("Get the current receiver passband filter bounds (low/high Hz) for the active slice.")]
+    public string GetFilter()
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        var filter = _radioManager.GetFilter();
+        if (filter == null)
+            return "No active slice.";
+
+        return JsonSerializer.Serialize(new { FilterLow = filter.Value.Low, FilterHigh = filter.Value.High }, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool, Description("Set the receiver passband filter bounds in Hz. Example: low=200, high=1000 for narrow CW.")]
+    public string SetFilter(int low, int high)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        bool ok = _radioManager.SetFilter(low, high);
+        return ok ? $"Filter set to {low}-{high} Hz" : "No active slice.";
+    }
+
     [McpServerTool, Description("Get real-time meter readings from the radio including S-meter, SWR, forward/reflected power, PA temperature, voltage, mic level, ALC, and compression. Values update continuously while connected.")]
     public string GetMeters()
     {

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -136,6 +136,21 @@ public class RadioManager : IDisposable
         return true;
     }
 
+    public (int Low, int High)? GetFilter()
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return null;
+        return (slice.FilterLow, slice.FilterHigh);
+    }
+
+    public bool SetFilter(int low, int high)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        slice.UpdateFilter(low, high);
+        return true;
+    }
+
     public bool SetActiveSlice(int sliceIndex)
     {
         var radio = _radio;


### PR DESCRIPTION
## Summary
- Adds `GetFilter()` and `SetFilter(int low, int high)` methods to `RadioManager` for reading/writing the active slice's receiver passband filter bounds
- Adds `get_filter` and `set_filter` MCP tool endpoints to `RadioTools` for external clients

Closes #5

## Test plan
- [ ] Connect to radio, call `get_filter` and verify it returns current FilterLow/FilterHigh values
- [ ] Call `set_filter` with low=200, high=1000 and verify filter changes on the radio
- [ ] Verify error handling when no radio connected or no active slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)