### PR TITLE
Add set_rit and set_xit MCP tools

### DIFF
--- a/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
@@ -178,6 +178,24 @@ public class RadioTools
         return JsonSerializer.Serialize(meters, new JsonSerializerOptions { WriteIndented = true });
     }
 
+    [McpServerTool, Description("Set RIT (Receiver Incremental Tuning). Enable/disable and set offset in Hz.")]
+    public string SetRit(bool? enabled = null, int? offsetHz = null)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+        bool ok = _radioManager.SetRit(enabled, offsetHz);
+        return ok ? $"RIT set: enabled={enabled?.ToString() ?? "unchanged"}, offset={offsetHz?.ToString() ?? "unchanged"} Hz" : "No active slice.";
+    }
+
+    [McpServerTool, Description("Set XIT (Transmitter Incremental Tuning). Enable/disable and set offset in Hz.")]
+    public string SetXit(bool? enabled = null, int? offsetHz = null)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+        bool ok = _radioManager.SetXit(enabled, offsetHz);
+        return ok ? $"XIT set: enabled={enabled?.ToString() ?? "unchanged"}, offset={offsetHz?.ToString() ?? "unchanged"} Hz" : "No active slice.";
+    }
+
     [McpServerTool, Description("Set CW profile values in one operation. All params optional: wpm, pitch, breakIn, iambic.")]
     public string SetCwProfile(int? wpm = null, int? pitch = null, bool? breakIn = null, string? iambic = null)
     {

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -148,6 +148,24 @@ public class RadioManager : IDisposable
         return true;
     }
 
+    public bool SetRit(bool? enabled, int? offsetHz)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        if (enabled.HasValue) slice.RITOn = enabled.Value;
+        if (offsetHz.HasValue) slice.RITFreq = offsetHz.Value;
+        return true;
+    }
+
+    public bool SetXit(bool? enabled, int? offsetHz)
+    {
+        var slice = GetActiveSlice();
+        if (slice == null) return false;
+        if (enabled.HasValue) slice.XITOn = enabled.Value;
+        if (offsetHz.HasValue) slice.XITFreq = offsetHz.Value;
+        return true;
+    }
+
     public bool StepFrequency(int stepHz, out double newFrequencyMHz)
     {
         newFrequencyMHz = 0;


### PR DESCRIPTION
## Summary
- Add `SetRit` and `SetXit` methods to `RadioManager` for controlling RIT/XIT on the active slice (enable/disable + Hz offset)
- Add `set_rit` and `set_xit` MCP tool endpoints in `RadioTools` with connection and slice validation

Closes #6

## Test plan
- [ ] Connect to radio, call `set_rit(enabled: true, offsetHz: 150)` and verify RIT activates with correct offset
- [ ] Call `set_xit(enabled: true, offsetHz: -200)` and verify XIT activates
- [ ] Call with only `enabled` or only `offsetHz` to verify partial updates work
- [ ] Call when disconnected and verify "Not connected" message
- [ ] Call with no active slice and verify "No active slice" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)