### PR TITLE
Add list_slices MCP tool

### DIFF
--- a/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
@@ -178,6 +178,19 @@ public class RadioTools
         return JsonSerializer.Serialize(meters, new JsonSerializerOptions { WriteIndented = true });
     }
 
+    [McpServerTool, Description("List all receiver slices with their configuration: frequency, mode, filter, antenna, AGC, noise reduction, and more.")]
+    public string ListSlices()
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio.";
+
+        var slices = _radioManager.ListSlices();
+        if (slices.Count == 0)
+            return "No slices available.";
+
+        return JsonSerializer.Serialize(slices, new JsonSerializerOptions { WriteIndented = true });
+    }
+
     [McpServerTool, Description("Set CW profile values in one operation. All params optional: wpm, pitch, breakIn, iambic.")]
     public string SetCwProfile(int? wpm = null, int? pitch = null, bool? breakIn = null, string? iambic = null)
     {

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -227,6 +227,38 @@ public class RadioManager : IDisposable
         return false;
     }
 
+    public List<object> ListSlices()
+    {
+        var radio = _radio;
+        if (radio == null || !radio.Connected) return [];
+
+        return radio.SliceList.Select(s => (object)new
+        {
+            s.Index,
+            s.Letter,
+            s.Active,
+            FrequencyMHz = s.Freq,
+            Mode = s.DemodMode,
+            s.FilterLow,
+            s.FilterHigh,
+            s.DAXChannel,
+            s.RXAnt,
+            s.TXAnt,
+            s.AGCMode,
+            s.AudioGain,
+            s.AudioPan,
+            s.Mute,
+            s.NROn,
+            s.NBOn,
+            s.ANFOn,
+            s.IsTransmitSlice,
+            s.RITOn,
+            s.RITFreq,
+            s.XITOn,
+            s.XITFreq
+        }).ToList();
+    }
+
     public Dictionary<string, object> GetMeters()
     {
         var radio = _radio;


### PR DESCRIPTION
## Summary
- Adds `ListSlices()` method to `RadioManager` that returns all slice configurations (index, frequency, mode, filter, antenna, AGC, noise reduction, RIT/XIT, etc.)
- Adds `ListSlices` MCP tool in `RadioTools` that serializes slice data as JSON
- Closes #7

## Test plan
- [ ] Connect to a FlexRadio with one or more slices active
- [ ] Call the `list_slices` tool and verify all slice properties are returned
- [ ] Verify "Not connected" message when radio is disconnected
- [ ] Verify "No slices available" when connected but no slices exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)