### PR TITLE
Add GPS, TNF, RF power, ATU, memory, spots, and AGC tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The design keeps humans in the loop: no RF is ever emitted without explicit appr
 - Read real-time meters: S-meter, SWR, forward/reflected power, PA temperature, voltage, ALC
 - Set RF transmit power and tune power levels
 - Manage Tracking Notch Filters (TNF) to null out interference
-- Control antenna tuner (ATU): status, enable/disable, auto-tune
+- Control antenna tuner (ATU): status and auto-tune
 - Save, load, and delete memory channels
 - View and manage DX spots
 - Read GPS/GNSS data: grid square, coordinates, altitude, satellites
@@ -217,7 +217,7 @@ Or, if you prefer to run the compiled binary:
 | `list_spots` | — | List all DX spots with callsign, frequency, mode, spotter |
 | `remove_spot` | `callsign` | Remove a DX spot by callsign |
 | `get_agc` | — | Get AGC settings (mode, threshold, off-level) |
-| `set_agc` | `mode?`, `threshold?`, `offLevel?` | Set AGC mode (off/slow/med/fast) and threshold |
+| `set_agc` | `mode?`, `threshold?`, `offLevel?` | Set AGC mode (off/slow/medium/fast) and threshold |
 
 ### CW Listener Tools
 

--- a/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/RadioTools.cs
@@ -349,7 +349,7 @@ public class RadioTools
         return ok ? $"Spot for {callsign} removed." : $"Spot for {callsign} not found.";
     }
 
-    [McpServerTool, Description("Get AGC (Automatic Gain Control) settings for the active slice: mode (off/slow/med/fast), threshold, off-level.")]
+    [McpServerTool, Description("Get AGC (Automatic Gain Control) settings for the active slice: mode (off/slow/medium/fast), threshold, off-level.")]
     public string GetAgc()
     {
         if (!_radioManager.IsConnected)
@@ -358,7 +358,7 @@ public class RadioTools
         return agc == null ? "No active slice." : JsonSerializer.Serialize(agc, new JsonSerializerOptions { WriteIndented = true });
     }
 
-    [McpServerTool, Description("Set AGC mode (off, slow, med, fast), threshold, and/or off-level for the active slice.")]
+    [McpServerTool, Description("Set AGC mode (off, slow, medium, fast), threshold, and/or off-level for the active slice.")]
     public string SetAgc(string? mode = null, int? threshold = null, int? offLevel = null)
     {
         if (!_radioManager.IsConnected)

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -514,8 +514,17 @@ public class RadioManager : IDisposable
     {
         var slice = GetActiveSlice();
         if (slice == null) return false;
-        if (mode != null && Enum.TryParse<AGCMode>(mode, true, out var agcMode))
-            slice.AGCMode = agcMode;
+        if (mode != null)
+        {
+            var normalizedMode = mode;
+            if (normalizedMode.Equals("med", StringComparison.OrdinalIgnoreCase))
+                normalizedMode = "Medium";
+
+            if (Enum.TryParse<AGCMode>(normalizedMode, true, out var agcMode))
+                slice.AGCMode = agcMode;
+            else
+                return false;
+        }
         if (threshold.HasValue) slice.AGCThreshold = threshold.Value;
         if (offLevel.HasValue) slice.AGCOffLevel = offLevel.Value;
         return true;


### PR DESCRIPTION
## Summary
Adds 7 new MCP tool groups exposing FlexLib radio functionality:

- **GPS** (`get_gps`) — grid square, coordinates, altitude, satellites, frequency error
- **TNF** (`list_tnfs`, `add_tnf`, `remove_tnf`) — Tracking Notch Filter management
- **RF Power** (`get_rf_power`, `set_rf_power`) — transmit and tune power control
- **ATU** (`get_atu_status`, `atu_tune`) — antenna tuner status and auto-tune
- **Memories** (`list_memories`, `load_memory`, `delete_memory`) — channel memory management
- **DX Spots** (`list_spots`, `remove_spot`) — DX spot listing and removal
- **AGC** (`get_agc`, `set_agc`) — AGC mode (off/slow/med/fast), threshold, off-level

Also updates README with all new tools in both the features section and MCP tools reference table.

## Test plan
- [ ] `get_gps` — verify GPS data returns (or gracefully handles no GPS)
- [ ] `list_tnfs` / `add_tnf` / `remove_tnf` — create, list, and remove a TNF
- [ ] `get_rf_power` / `set_rf_power` — read and adjust power levels
- [ ] `get_atu_status` / `atu_tune` — check ATU status, trigger tune
- [ ] `list_memories` / `load_memory` / `delete_memory` — memory channel CRUD
- [ ] `list_spots` / `remove_spot` — spot listing and removal
- [ ] `get_agc` / `set_agc` — read and change AGC settings

Closes #9, #10, #11, #12, #13, #14, #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)