### PR TITLE
Add Band Scout, DX Hunter, and high-value radio tools

### DIFF
--- a/src/SmartSdrMcp.Ai/CwAiRescorer.cs
+++ b/src/SmartSdrMcp.Ai/CwAiRescorer.cs
@@ -1,0 +1,175 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SmartSdrMcp.Cw.Decoder;
+
+namespace SmartSdrMcp.Ai;
+
+/// <summary>
+/// AI-powered CW text rescorer that uses Claude to correct decode errors
+/// by considering N-best character alternatives and ham radio context.
+/// </summary>
+public class CwAiRescorer
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _model;
+
+    public CwAiRescorer(HttpClient httpClient, string model = "claude-haiku-4-5-20251001")
+    {
+        _httpClient = httpClient;
+        _model = model;
+    }
+
+    /// <summary>
+    /// Rescore decoded CW text using AI, considering alternative character candidates.
+    /// Returns the corrected text, or the original if the API call fails.
+    /// </summary>
+    public async Task<AiRescoreResult> RescoreAsync(string rawText, List<DecodedCharacter> characters)
+    {
+        if (string.IsNullOrWhiteSpace(rawText))
+            return new AiRescoreResult(rawText, rawText, false, "Empty input");
+
+        var prompt = BuildPrompt(rawText, characters);
+
+        try
+        {
+            var request = new
+            {
+                model = _model,
+                max_tokens = 1024,
+                messages = new[]
+                {
+                    new { role = "user", content = prompt }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(request);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync("https://api.anthropic.com/v1/messages", content);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync();
+                return new AiRescoreResult(rawText, rawText, false, $"API error {response.StatusCode}: {errorBody}");
+            }
+
+            var responseJson = await response.Content.ReadAsStringAsync();
+            var apiResponse = JsonSerializer.Deserialize<AnthropicResponse>(responseJson);
+            var corrected = apiResponse?.Content?.FirstOrDefault()?.Text?.Trim();
+
+            if (string.IsNullOrWhiteSpace(corrected))
+                return new AiRescoreResult(rawText, rawText, false, "Empty API response");
+
+            return new AiRescoreResult(rawText, corrected, true, null);
+        }
+        catch (Exception ex)
+        {
+            return new AiRescoreResult(rawText, rawText, false, ex.Message);
+        }
+    }
+
+    private static string BuildPrompt(string rawText, List<DecodedCharacter> characters)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("You are an expert CW (Morse code) decoder post-processor for ham radio.");
+        sb.AppendLine("The raw decoder output below is HEAVILY corrupted by dit/dah timing errors.");
+        sb.AppendLine("Your job is to AGGRESSIVELY reconstruct the most likely original message.");
+        sb.AppendLine();
+        sb.AppendLine("IMPORTANT: Do NOT treat the raw text as mostly correct. It is often very wrong.");
+        sb.AppendLine("You must reconstruct whole words and phrases, not just fix individual characters.");
+        sb.AppendLine("Use the character-level alternatives AND your knowledge of ham radio QSO structure.");
+        sb.AppendLine();
+        sb.AppendLine("## Ham radio QSO structure (typical exchange):");
+        sb.AppendLine("  CQ CQ CQ DE <callsign> <callsign> K");
+        sb.AppendLine("  <their-call> DE <my-call> GM/GA/GE UR RST 599 599 QTH <location> NAME <name> HW CPY? BK");
+        sb.AppendLine("  R R TU FB OM <name> UR RST 599 HR QTH <location> RIG <rig> ANT <antenna> WX <weather> 73 TU SK");
+        sb.AppendLine();
+        sb.AppendLine("## Common QSO vocabulary:");
+        sb.AppendLine("  CQ, DE, K, BK, SK, AR, KN, R, TU, 73, 88, 599, 5NN, RST, UR, QTH, QSL, QRZ");
+        sb.AppendLine("  NAME, RIG, ANT, WX, HR, HW, CPY, GE, GM, GA, GN, FB, OM, ES, DR, AGN, PSE");
+        sb.AppendLine("  SOLID, GOOD, FINE, NICE, HERE, FIRST, TEST, CONTEST");
+        sb.AppendLine();
+        sb.AppendLine("## Callsign format:");
+        sb.AppendLine("  1-2 letter prefix + 1 digit + 1-3 letter suffix (e.g., K1AF, W3ABC, VE7XYZ, N7SME, UA3DX)");
+        sb.AppendLine("  Callsigns are VERY common — look for letter-digit-letter patterns in the garbled text.");
+        sb.AppendLine();
+        sb.AppendLine("## Known decoder confusions (dit↔dah errors cause these swaps):");
+        sb.AppendLine("  Single element: T(-)↔E(.)");
+        sb.AppendLine("  Two elements: I(..)↔A(.-)↔N(-.)↔M(--)");
+        sb.AppendLine("  Three elements: S(...)↔U(..)↔R(.-.)↔D(-..)↔K(-.-)↔G(--.)↔W(.--)↔O(---)");
+        sb.AppendLine("  Four elements: H(....)↔V(..-)↔F(..-.)↔B(-...)↔L(.-..)↔C(-..-.)↔P(.--..)↔Z(--..)");
+        sb.AppendLine("  The decoder often outputs runs of T,E,I,N,H,S — these are usually longer characters with timing errors.");
+        sb.AppendLine();
+        sb.AppendLine("## Raw decoded text:");
+        sb.AppendLine(rawText);
+        sb.AppendLine();
+
+        // Build per-character detail with alternatives
+        sb.AppendLine("## Character-by-character decode (position: char [pattern] confidence, alternatives):");
+        for (int i = 0; i < characters.Count; i++)
+        {
+            var ch = characters[i];
+            var line = $"  {i}: '{ch.Character}' [{ch.DitDahPattern}] {ch.Confidence:F1}";
+            if (ch.Alternatives is { Count: > 0 })
+            {
+                var alts = string.Join(" ", ch.Alternatives.Select(a => $"{a.Character}({a.Score:F2})"));
+                line += $"  alts: {alts}";
+            }
+            sb.AppendLine(line);
+        }
+        sb.AppendLine();
+
+        // Add word boundaries from spaces
+        var words = rawText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length > 1)
+        {
+            sb.AppendLine("## Word-level segments:");
+            foreach (var w in words)
+                sb.AppendLine($"  [{w}]");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("## Instructions:");
+        sb.AppendLine("1. For each segment of garbled text, consider ALL possible character substitutions from the confusion groups above.");
+        sb.AppendLine("2. Try to form recognizable ham radio words, callsigns, RST reports, or common abbreviations.");
+        sb.AppendLine("3. If a segment could be a callsign (has a digit surrounded by letters), try to reconstruct it.");
+        sb.AppendLine("4. Unknown patterns ?(xxx) usually represent characters the decoder couldn't match — try to figure out what they are.");
+        sb.AppendLine("5. Prefer interpretations that form a coherent QSO exchange.");
+        sb.AppendLine();
+        sb.AppendLine("Output ONLY the reconstructed text. No explanation, no commentary. Just the corrected ham radio message.");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Configure the HTTP client with the Anthropic API key.
+    /// </summary>
+    public static void ConfigureHttpClient(HttpClient client, string apiKey)
+    {
+        client.DefaultRequestHeaders.Clear();
+        client.DefaultRequestHeaders.Add("x-api-key", apiKey);
+        client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+
+    // Response models for Anthropic API
+    private class AnthropicResponse
+    {
+        [JsonPropertyName("content")]
+        public List<ContentBlock>? Content { get; set; }
+    }
+
+    private class ContentBlock
+    {
+        [JsonPropertyName("text")]
+        public string? Text { get; set; }
+    }
+}
+
+public record AiRescoreResult(
+    string OriginalText,
+    string CorrectedText,
+    bool AiApplied,
+    string? Error);

--- a/src/SmartSdrMcp.Ai/CwAiRescorer.cs
+++ b/src/SmartSdrMcp.Ai/CwAiRescorer.cs
@@ -15,10 +15,14 @@ public class CwAiRescorer
     private readonly HttpClient _httpClient;
     private readonly string _model;
 
-    public CwAiRescorer(HttpClient httpClient, string model = "claude-haiku-4-5-20251001")
+    private const string DefaultModel = "claude-haiku-4-5-20251001";
+
+    public CwAiRescorer(HttpClient httpClient, string? model = null)
     {
         _httpClient = httpClient;
-        _model = model;
+        _model = model
+            ?? Environment.GetEnvironmentVariable("ANTHROPIC_MODEL")
+            ?? DefaultModel;
     }
 
     /// <summary>

--- a/src/SmartSdrMcp.Ai/CwAiRescorer.cs
+++ b/src/SmartSdrMcp.Ai/CwAiRescorer.cs
@@ -47,7 +47,7 @@ public class CwAiRescorer
             var json = JsonSerializer.Serialize(request);
             var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-            var response = await _httpClient.PostAsync("https://api.anthropic.com/v1/messages", content);
+            using var response = await _httpClient.PostAsync("https://api.anthropic.com/v1/messages", content);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/SmartSdrMcp.Ai/SmartSdrMcp.Ai.csproj
+++ b/src/SmartSdrMcp.Ai/SmartSdrMcp.Ai.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SmartSdrMcp.Qso\SmartSdrMcp.Qso.csproj" />
+    <ProjectReference Include="..\SmartSdrMcp.Cw\SmartSdrMcp.Cw.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SmartSdrMcp.Cw/CwPipeline.cs
+++ b/src/SmartSdrMcp.Cw/CwPipeline.cs
@@ -109,6 +109,18 @@ public class CwPipeline : IDisposable
         }
     }
 
+    /// <summary>
+    /// Get recent decoded characters with their N-best alternatives for AI rescoring.
+    /// </summary>
+    public List<DecodedCharacter> GetRecentCharacters(int count = 100)
+    {
+        lock (_textLock)
+        {
+            int start = Math.Max(0, _recentChars.Count - count);
+            return _recentChars.Skip(start).ToList();
+        }
+    }
+
     public void ClearLiveText()
     {
         lock (_textLock) _liveBuffer = "";

--- a/src/SmartSdrMcp.Cw/Decoder/MorseDecoder.cs
+++ b/src/SmartSdrMcp.Cw/Decoder/MorseDecoder.cs
@@ -171,6 +171,12 @@ public class MorseDecoder
                 .ToList();
         }
 
+        // Precompute position → ambiguous index mapping to avoid O(n²) IndexOf
+        var ambiguousIndex = new int[_currentCandidates.Count];
+        Array.Fill(ambiguousIndex, -1);
+        for (int ai = 0; ai < ambiguous.Count; ai++)
+            ambiguousIndex[ambiguous[ai]] = ai;
+
         var results = new List<CharacterCandidate>();
         int combos = 1 << ambiguous.Count;
 
@@ -181,7 +187,7 @@ public class MorseDecoder
 
             for (int i = 0; i < _currentCandidates.Count; i++)
             {
-                int ambIdx = ambiguous.IndexOf(i);
+                int ambIdx = ambiguousIndex[i];
                 bool flip = ambIdx >= 0 && (mask & (1 << ambIdx)) != 0;
 
                 if (flip)

--- a/src/SmartSdrMcp.Cw/Decoder/MorseDecoder.cs
+++ b/src/SmartSdrMcp.Cw/Decoder/MorseDecoder.cs
@@ -9,6 +9,7 @@ public class MorseDecoder
 {
     private readonly WpmEstimator _wpmEstimator;
     private readonly List<MorseElement> _currentPattern = new();
+    private readonly List<SymbolCandidate> _currentCandidates = new();
     private string _currentDitDah = "";
     private DateTime _lastKeyUpTime = DateTime.UtcNow;
     private bool _inCharacter;
@@ -50,6 +51,7 @@ public class MorseDecoder
             }
 
             _currentPattern.Add(symbol.Element);
+            _currentCandidates.Add(symbol);
             _inCharacter = true;
             _lastKeyUpTime = keyEvent.EndTime;
 
@@ -125,21 +127,91 @@ public class MorseDecoder
         string? decoded = MorseTable.Lookup(_currentDitDah);
         double confidence = decoded != null ? 0.9 : 0.3;
 
+        // Generate N-best alternative characters from ambiguous elements
+        var alternatives = GenerateAlternatives();
+
         CharacterDecoded?.Invoke(new DecodedCharacter(
             _currentDitDah,
             decoded ?? $"?({_currentDitDah})",
             confidence,
-            DateTime.UtcNow));
+            DateTime.UtcNow,
+            alternatives.Count > 0 ? alternatives : null));
 
         _currentDitDah = "";
         _currentPattern.Clear();
+        _currentCandidates.Clear();
         _inCharacter = false;
+    }
+
+    /// <summary>
+    /// Generate alternative character interpretations by flipping ambiguous elements.
+    /// Only considers elements where the alternative confidence > 0.15.
+    /// Returns up to 5 candidates sorted by score.
+    /// </summary>
+    private List<CharacterCandidate> GenerateAlternatives()
+    {
+        if (_currentCandidates.Count == 0) return new();
+
+        // Find ambiguous positions (where alternative is plausible)
+        var ambiguous = new List<int>();
+        for (int i = 0; i < _currentCandidates.Count; i++)
+        {
+            if (_currentCandidates[i].Alternative.HasValue && _currentCandidates[i].AltConfidence > 0.15)
+                ambiguous.Add(i);
+        }
+
+        if (ambiguous.Count == 0) return new();
+
+        // Limit to the 3 most ambiguous positions to keep combinations manageable
+        if (ambiguous.Count > 3)
+        {
+            ambiguous = ambiguous
+                .OrderByDescending(i => _currentCandidates[i].AltConfidence)
+                .Take(3)
+                .ToList();
+        }
+
+        var results = new List<CharacterCandidate>();
+        int combos = 1 << ambiguous.Count;
+
+        for (int mask = 1; mask < combos; mask++)
+        {
+            var pattern = new char[_currentCandidates.Count];
+            double score = 1.0;
+
+            for (int i = 0; i < _currentCandidates.Count; i++)
+            {
+                int ambIdx = ambiguous.IndexOf(i);
+                bool flip = ambIdx >= 0 && (mask & (1 << ambIdx)) != 0;
+
+                if (flip)
+                {
+                    pattern[i] = _currentCandidates[i].Alternative == MorseElement.Dit ? '.' : '-';
+                    score *= _currentCandidates[i].AltConfidence;
+                }
+                else
+                {
+                    pattern[i] = _currentCandidates[i].Element == MorseElement.Dit ? '.' : '-';
+                    score *= _currentCandidates[i].Confidence;
+                }
+            }
+
+            string patternStr = new(pattern);
+            if (patternStr == _currentDitDah) continue;
+
+            string? ch = MorseTable.Lookup(patternStr);
+            if (ch != null)
+                results.Add(new CharacterCandidate(patternStr, ch, score));
+        }
+
+        return results.OrderByDescending(c => c.Score).Take(5).ToList();
     }
 
     public void Reset()
     {
         _currentDitDah = "";
         _currentPattern.Clear();
+        _currentCandidates.Clear();
         _inCharacter = false;
     }
 }
@@ -148,4 +220,5 @@ public record DecodedCharacter(
     string DitDahPattern,
     string Character,
     double Confidence,
-    DateTime Timestamp);
+    DateTime Timestamp,
+    List<CharacterCandidate>? Alternatives = null);

--- a/src/SmartSdrMcp.Cw/Decoder/SymbolCandidate.cs
+++ b/src/SmartSdrMcp.Cw/Decoder/SymbolCandidate.cs
@@ -7,3 +7,11 @@ public record SymbolCandidate(
     double Confidence,
     MorseElement? Alternative = null,
     double AltConfidence = 0);
+
+/// <summary>
+/// An alternative character interpretation with its dit-dah pattern and score.
+/// </summary>
+public record CharacterCandidate(
+    string DitDahPattern,
+    string Character,
+    double Score);

--- a/src/SmartSdrMcp.DxHunter/DxClusterService.cs
+++ b/src/SmartSdrMcp.DxHunter/DxClusterService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using SmartSdrMcp.BandScout;
 using SmartSdrMcp.Radio;
 
 namespace SmartSdrMcp.DxHunter;
@@ -15,8 +16,9 @@ public class DxClusterService : IDisposable
     private const string BaseUrl = "https://www.hamqth.com/dxc_csv.php";
 
     private Timer? _pollTimer;
-    private bool _running;
+    private volatile bool _running;
     private readonly object _lock = new();
+    private readonly SemaphoreSlim _pollGuard = new(1, 1); // prevent overlapping polls
     private readonly HashSet<string> _pushedSpots = new(); // "CALL|FREQ" dedup
     private readonly List<string> _statusLog = new();
 
@@ -93,14 +95,19 @@ public class DxClusterService : IDisposable
 
     private async Task PollAndPushSpots()
     {
+        if (!_running) return;
+        if (!_pollGuard.Wait(0)) return; // skip if another poll is already running
         try
         {
             var spots = await FetchSpots();
+            if (!_running) return; // re-check after async fetch
             int pushed = 0;
             int needCount = 0;
 
             foreach (var spot in spots)
             {
+                if (!_running) break;
+
                 var key = $"{spot.DxCall}|{spot.FrequencyKhz:F1}";
                 lock (_lock)
                 {
@@ -135,7 +142,7 @@ public class DxClusterService : IDisposable
                         spotMode = ModeFilter;
                 }
 
-                _radioManager.AddSpot(
+                bool spotPushed = _radioManager.AddSpot(
                     callsign: spot.DxCall,
                     frequencyMHz: freqMHz,
                     mode: spotMode,
@@ -146,8 +153,11 @@ public class DxClusterService : IDisposable
                     comment: comment,
                     lifetimeSeconds: SpotLifetimeSeconds);
 
-                pushed++;
-                if (isNeed) needCount++;
+                if (spotPushed)
+                {
+                    pushed++;
+                    if (isNeed) needCount++;
+                }
             }
 
             if (pushed > 0)
@@ -157,15 +167,23 @@ public class DxClusterService : IDisposable
         {
             LogStatus($"Poll error: {ex.Message}");
         }
+        finally
+        {
+            _pollGuard.Release();
+        }
     }
 
     private bool IsNeed(string callsign, double frequencyKhz)
     {
         if (_dxHunter == null || !_dxHunter.IsRunning) return false;
 
-        // Check if the DX hunter considers this a need by looking at its alert list
+        // Infer band from frequency for accurate matching
+        var band = BandScout.BandScoutMonitor.FrequencyToBand(frequencyKhz / 1000.0);
+
+        // Check if the DX hunter considers this a need on this specific band
         var needs = _dxHunter.GetNeeds();
-        return needs.Any(n => string.Equals(n.Callsign, callsign, StringComparison.OrdinalIgnoreCase));
+        return needs.Any(n => string.Equals(n.Callsign, callsign, StringComparison.OrdinalIgnoreCase)
+            && (band == "OOB" || string.Equals(n.Band, band, StringComparison.OrdinalIgnoreCase)));
     }
 
     private async Task<List<ClusterSpot>> FetchSpots()
@@ -198,11 +216,12 @@ public class DxClusterService : IDisposable
             var dtParts = fields[4].Trim().Split(' ');
             if (dtParts.Length == 2 && dtParts[0].Length == 4)
             {
-                if (DateTime.TryParse(dtParts[1], out var date) &&
+                if (DateTime.TryParse(dtParts[1], CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var date) &&
                     int.TryParse(dtParts[0][..2], out var hour) &&
                     int.TryParse(dtParts[0][2..], out var min))
                 {
-                    spotted = date.AddHours(hour).AddMinutes(min);
+                    spotted = new DateTime(date.Year, date.Month, date.Day, hour, min, 0, DateTimeKind.Utc);
                 }
             }
 

--- a/src/SmartSdrMcp.DxHunter/DxClusterService.cs
+++ b/src/SmartSdrMcp.DxHunter/DxClusterService.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using SmartSdrMcp.Radio;
+
+namespace SmartSdrMcp.DxHunter;
+
+/// <summary>
+/// Polls a DX cluster via HamQTH HTTP API and pushes spots to the radio's panadapter.
+/// Integrates with DxHunterAgent to highlight "needs" in a different color.
+/// </summary>
+public class DxClusterService : IDisposable
+{
+    private readonly RadioManager _radioManager;
+    private readonly DxHunterAgent? _dxHunter;
+    private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(10) };
+    private const string BaseUrl = "https://www.hamqth.com/dxc_csv.php";
+
+    private Timer? _pollTimer;
+    private bool _running;
+    private readonly object _lock = new();
+    private readonly HashSet<string> _pushedSpots = new(); // "CALL|FREQ" dedup
+    private readonly List<string> _statusLog = new();
+
+    // Configuration
+    public int PollIntervalSeconds { get; set; } = 30;
+    public string? BandFilter { get; set; }
+    public string? ModeFilter { get; set; }
+    public int SpotLifetimeSeconds { get; set; } = 600; // 10 minutes
+    public int MaxSpots { get; set; } = 50;
+
+    // Colors: AARRGGBB hex format for FlexRadio
+    public string NormalSpotColor { get; set; } = "#FF00BFFF";    // Deep sky blue
+    public string NeedSpotColor { get; set; } = "#FFFF4444";      // Red — DX need!
+    public string NeedSpotBgColor { get; set; } = "#44FF0000";    // Semi-transparent red bg
+
+    public bool IsRunning => _running;
+
+    public DxClusterService(RadioManager radioManager, DxHunterAgent? dxHunter = null)
+    {
+        _radioManager = radioManager;
+        _dxHunter = dxHunter;
+    }
+
+    public string Start(string? band = null, string? mode = null, int pollSeconds = 30)
+    {
+        if (_running) return "DX Cluster feed is already running.";
+        if (!_radioManager.IsConnected) return "Radio not connected.";
+
+        BandFilter = band;
+        ModeFilter = mode;
+        PollIntervalSeconds = Math.Max(15, pollSeconds); // minimum 15s to be polite
+
+        _running = true;
+        lock (_lock)
+        {
+            _pushedSpots.Clear();
+            _statusLog.Clear();
+            _statusLog.Add($"[{DateTime.UtcNow:HH:mm:ss}] DX Cluster started. Band={band ?? "all"}, Mode={mode ?? "all"}, Poll={PollIntervalSeconds}s");
+        }
+
+        // Poll immediately, then on timer
+        _ = PollAndPushSpots();
+        _pollTimer = new Timer(_ => _ = PollAndPushSpots(), null,
+            TimeSpan.FromSeconds(PollIntervalSeconds),
+            TimeSpan.FromSeconds(PollIntervalSeconds));
+
+        return $"DX Cluster feed started. Polling every {PollIntervalSeconds}s. Spots will appear on the panadapter.";
+    }
+
+    public string Stop()
+    {
+        _pollTimer?.Dispose();
+        _pollTimer = null;
+        _running = false;
+        LogStatus("DX Cluster feed stopped.");
+        return "DX Cluster feed stopped.";
+    }
+
+    public object GetStatus()
+    {
+        lock (_lock)
+        {
+            return new
+            {
+                IsRunning = _running,
+                BandFilter,
+                ModeFilter,
+                PollIntervalSeconds,
+                SpotsPushed = _pushedSpots.Count,
+                StatusLog = _statusLog.TakeLast(20).ToList()
+            };
+        }
+    }
+
+    private async Task PollAndPushSpots()
+    {
+        try
+        {
+            var spots = await FetchSpots();
+            int pushed = 0;
+            int needCount = 0;
+
+            foreach (var spot in spots)
+            {
+                var key = $"{spot.DxCall}|{spot.FrequencyKhz:F1}";
+                lock (_lock)
+                {
+                    if (_pushedSpots.Contains(key)) continue;
+                    if (_pushedSpots.Count >= MaxSpots * 2) // cleanup old entries
+                    {
+                        _pushedSpots.Clear();
+                    }
+                    _pushedSpots.Add(key);
+                }
+
+                var freqMHz = spot.FrequencyKhz / 1000.0;
+                bool isNeed = IsNeed(spot.DxCall, spot.FrequencyKhz);
+
+                string color = isNeed ? NeedSpotColor : NormalSpotColor;
+                string? bgColor = isNeed ? NeedSpotBgColor : null;
+                string comment = spot.Comment ?? "";
+                if (isNeed) comment = "** DX NEED ** " + comment;
+
+                // Use the actual mode if available, or infer from comment/filter
+                string? spotMode = spot.Mode;
+                if (string.IsNullOrEmpty(spotMode) || spotMode.Length <= 2)
+                {
+                    // HamQTH puts continent codes in mode field; check comment for real mode
+                    if (spot.Comment != null && spot.Comment.Contains("CW", StringComparison.OrdinalIgnoreCase))
+                        spotMode = "CW";
+                    else if (spot.Comment != null && spot.Comment.Contains("FT8", StringComparison.OrdinalIgnoreCase))
+                        spotMode = "FT8";
+                    else if (spot.Comment != null && spot.Comment.Contains("SSB", StringComparison.OrdinalIgnoreCase))
+                        spotMode = "SSB";
+                    else
+                        spotMode = ModeFilter;
+                }
+
+                _radioManager.AddSpot(
+                    callsign: spot.DxCall,
+                    frequencyMHz: freqMHz,
+                    mode: spotMode,
+                    color: color,
+                    backgroundColor: bgColor,
+                    spotterCallsign: spot.Spotter,
+                    source: "SmartSdrMcp-Cluster",
+                    comment: comment,
+                    lifetimeSeconds: SpotLifetimeSeconds);
+
+                pushed++;
+                if (isNeed) needCount++;
+            }
+
+            if (pushed > 0)
+                LogStatus($"Pushed {pushed} spots ({needCount} needs)");
+        }
+        catch (Exception ex)
+        {
+            LogStatus($"Poll error: {ex.Message}");
+        }
+    }
+
+    private bool IsNeed(string callsign, double frequencyKhz)
+    {
+        if (_dxHunter == null || !_dxHunter.IsRunning) return false;
+
+        // Check if the DX hunter considers this a need by looking at its alert list
+        var needs = _dxHunter.GetNeeds();
+        return needs.Any(n => string.Equals(n.Callsign, callsign, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task<List<ClusterSpot>> FetchSpots()
+    {
+        var url = $"{BaseUrl}?limit={MaxSpots}";
+        if (BandFilter != null)
+            url += $"&band={BandFilter}";
+        if (ModeFilter != null)
+            url += $"&mode={ModeFilter}";
+
+        var response = await _http.GetStringAsync(url);
+        return ParseSpots(response);
+    }
+
+    private static List<ClusterSpot> ParseSpots(string csv)
+    {
+        var spots = new List<ClusterSpot>();
+
+        foreach (var line in csv.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var fields = line.Split('^');
+            if (fields.Length < 5) continue;
+
+            if (!double.TryParse(fields[1], CultureInfo.InvariantCulture, out var freq)) continue;
+
+            var call = fields[2].Trim();
+            if (string.IsNullOrEmpty(call)) continue;
+
+            DateTime spotted = DateTime.UtcNow;
+            var dtParts = fields[4].Trim().Split(' ');
+            if (dtParts.Length == 2 && dtParts[0].Length == 4)
+            {
+                if (DateTime.TryParse(dtParts[1], out var date) &&
+                    int.TryParse(dtParts[0][..2], out var hour) &&
+                    int.TryParse(dtParts[0][2..], out var min))
+                {
+                    spotted = date.AddHours(hour).AddMinutes(min);
+                }
+            }
+
+            string? mode = fields.Length > 7 ? fields[7].Trim() : null;
+            if (string.IsNullOrEmpty(mode)) mode = null;
+
+            spots.Add(new ClusterSpot(
+                Spotter: fields[0].Trim(),
+                FrequencyKhz: freq,
+                DxCall: call,
+                Comment: fields.Length > 3 ? fields[3].Trim() : null,
+                SpottedUtc: spotted,
+                Band: fields.Length > 8 ? fields[8].Trim() : null,
+                Mode: mode,
+                Country: fields.Length > 9 ? fields[9].Trim() : null));
+        }
+
+        return spots;
+    }
+
+    private void LogStatus(string message)
+    {
+        lock (_lock)
+        {
+            _statusLog.Add($"[{DateTime.UtcNow:HH:mm:ss}] {message}");
+            while (_statusLog.Count > 100) _statusLog.RemoveAt(0);
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _http.Dispose();
+    }
+}
+
+public record ClusterSpot(
+    string Spotter,
+    double FrequencyKhz,
+    string DxCall,
+    string? Comment,
+    DateTime SpottedUtc,
+    string? Band,
+    string? Mode,
+    string? Country);

--- a/src/SmartSdrMcp.DxHunter/DxClusterService.cs
+++ b/src/SmartSdrMcp.DxHunter/DxClusterService.cs
@@ -19,7 +19,7 @@ public class DxClusterService : IDisposable
     private volatile bool _running;
     private readonly object _lock = new();
     private readonly SemaphoreSlim _pollGuard = new(1, 1); // prevent overlapping polls
-    private readonly HashSet<string> _pushedSpots = new(); // "CALL|FREQ" dedup
+    private readonly HashSet<string> _pushedSpots = new(StringComparer.OrdinalIgnoreCase); // "CALL|FREQ" dedup
     private readonly List<string> _statusLog = new();
 
     // Configuration

--- a/src/SmartSdrMcp.DxHunter/DxHunterAgent.cs
+++ b/src/SmartSdrMcp.DxHunter/DxHunterAgent.cs
@@ -152,7 +152,7 @@ public class DxHunterAgent
             _listenedAlerts.Clear();
             var bandInfo = string.IsNullOrEmpty(_targetBand) ? "all bands" : _targetBand;
             var modeInfo = string.IsNullOrEmpty(_targetMode) ? "all modes" : _targetMode;
-            var listenInfo = autoTune && _cwPipeline != null ? $", Listen={_listenDurationSeconds}s" : "";
+            var listenInfo = autoTune && (_cwPipeline != null || _ssbPipeline != null) ? $", Listen={_listenDurationSeconds}s" : "";
             LogStatus($"DX Hunter started. Watching {bandInfo}, {modeInfo}. AutoTune={autoTune}{listenInfo}.");
         }
 
@@ -497,9 +497,9 @@ public class DxHunterAgent
         // TUNE carrier if band changed — keys TX at 5W, watches SWR until it stabilizes
         if (bandChanged && spotBand != "OOB")
         {
-            // Check TX guard — don't transmit if inhibited
+            // Treat missing _txController as TX-inhibited so we never key without safety enforcement
             var txGuard = _txController?.GetTxGuardState();
-            if (txGuard != null && !txGuard.Armed)
+            if (txGuard == null || !txGuard.Armed)
             {
                 lock (_lock) { LogStatus($"Band change: {_currentBand} → {spotBand} — TX inhibited, skipping TUNE."); }
                 _currentBand = spotBand;
@@ -510,32 +510,31 @@ public class DxHunterAgent
                 _currentBand = spotBand;
 
                 // Save prior tune power to restore after
-                int? priorTunePower = null;
-                var rfState = _radioManager.GetRfPower();
-                if (rfState != null)
+                int? priorTunePower = _radioManager.GetTunePower();
+
+                // Key TUNE through TransmitController for band-edge safety enforcement
+                var tuneStart = _txController!.TxTune(tunePower: 5);
+                if (!tuneStart.Success)
                 {
-                    var tpProp = rfState.GetType().GetProperty("TunePower");
-                    if (tpProp?.GetValue(rfState) is int tp) priorTunePower = tp;
+                    lock (_lock) { LogStatus($"TUNE blocked: {tuneStart.Message}"); }
                 }
+                else
+                {
+                    // Wait for SWR to stabilize (< 2.0) or timeout at 10s
+                    var tuneResult = WaitForSwrStable(maxWaitMs: 10_000, targetSwr: 2.0, stableReadings: 3);
 
-                // Set tune power to 5W, then key the TUNE carrier
-                _radioManager.SetRfPower(rfPower: null, tunePower: 5);
-                _radioManager.SetTx(mox: null, txTune: true, txMonitor: null, txInhibit: null);
+                    // Stop TUNE via TransmitController
+                    _txController!.TxTuneStop();
 
-                // Wait for SWR to stabilize (< 2.0) or timeout at 10s
-                var tuneResult = WaitForSwrStable(maxWaitMs: 10_000, targetSwr: 2.0, stableReadings: 3);
+                    // Restore prior tune power
+                    if (priorTunePower.HasValue)
+                        _radioManager.SetRfPower(rfPower: null, tunePower: priorTunePower.Value);
 
-                // Stop TUNE
-                _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
+                    if (!_running) return;
 
-                // Restore prior tune power
-                if (priorTunePower.HasValue)
-                    _radioManager.SetRfPower(rfPower: null, tunePower: priorTunePower.Value);
-
-                if (!_running) return;
-
-                Thread.Sleep(300); // brief settle time
-                lock (_lock) { LogStatus(tuneResult); }
+                    Thread.Sleep(300); // brief settle time
+                    lock (_lock) { LogStatus(tuneResult); }
+                }
             }
         }
         else if (spotBand != "OOB")
@@ -702,9 +701,12 @@ public class DxHunterAgent
     private void LogStatus(string message)
     {
         var entry = $"[{DateTime.UtcNow:HH:mm:ss}] {message}";
-        _statusLog.Add(entry);
-        if (_statusLog.Count > MaxStatusLog)
-            _statusLog.RemoveAt(0);
+        lock (_lock)
+        {
+            _statusLog.Add(entry);
+            if (_statusLog.Count > MaxStatusLog)
+                _statusLog.RemoveAt(0);
+        }
         Console.Error.WriteLine($"[DXHUNTER] {message}");
     }
 

--- a/src/SmartSdrMcp.DxHunter/DxHunterAgent.cs
+++ b/src/SmartSdrMcp.DxHunter/DxHunterAgent.cs
@@ -1,13 +1,22 @@
+using SmartSdrMcp.Ai;
 using SmartSdrMcp.BandScout;
+using SmartSdrMcp.Cw;
 using SmartSdrMcp.Radio;
+using SmartSdrMcp.Ssb;
 
 namespace SmartSdrMcp.DxHunter;
 
 public class DxHunterAgent
 {
     private readonly RadioManager _radioManager;
+    private readonly CwPipeline? _cwPipeline;
+    private readonly CwAiRescorer? _aiRescorer;
+    private readonly SsbPipeline? _ssbPipeline;
     private readonly object _lock = new();
     private readonly List<string> _statusLog = new();
+    private readonly List<ListenResult> _listenResults = new();
+    private const int MaxListenResults = 50;
+    private int _listenDurationSeconds = 15;
 
     // Worked log: set of "ENTITY|BAND" and "ENTITY|BAND|MODE" keys
     private readonly HashSet<string> _workedEntityBand = new(StringComparer.OrdinalIgnoreCase);
@@ -21,6 +30,7 @@ public class DxHunterAgent
     private const int MaxAlerts = 100;
     private const int MaxStatusLog = 50;
     private const int PollIntervalMs = 10_000; // 10 seconds
+    private readonly HashSet<string> _listenedAlerts = new(StringComparer.OrdinalIgnoreCase); // track what we've already listened to
 
     private Thread? _hunterThread;
     private volatile bool _running;
@@ -28,12 +38,16 @@ public class DxHunterAgent
     private string _targetBand = ""; // empty = all bands
     private string _targetMode = ""; // empty = all modes
     private bool _autoTune;
+    private string _currentBand = ""; // track band for ATU tune on change
 
     public bool IsRunning => _running;
 
-    public DxHunterAgent(RadioManager radioManager)
+    public DxHunterAgent(RadioManager radioManager, CwPipeline? cwPipeline = null, CwAiRescorer? aiRescorer = null, SsbPipeline? ssbPipeline = null)
     {
         _radioManager = radioManager;
+        _cwPipeline = cwPipeline;
+        _aiRescorer = aiRescorer;
+        _ssbPipeline = ssbPipeline;
     }
 
     // Allowed file extensions for log files
@@ -111,7 +125,7 @@ public class DxHunterAgent
     /// <summary>
     /// Start the DX Hunter agent.
     /// </summary>
-    public string Start(string? band = null, string? mode = null, bool autoTune = false)
+    public string Start(string? band = null, string? mode = null, bool autoTune = false, int listenSeconds = 15)
     {
         if (_running) return "DX Hunter is already running.";
         if (!_radioManager.IsConnected) return "Not connected to a radio.";
@@ -122,6 +136,7 @@ public class DxHunterAgent
         _targetBand = band?.Trim() ?? "";
         _targetMode = mode?.Trim().ToUpperInvariant() ?? "";
         _autoTune = autoTune;
+        _listenDurationSeconds = Math.Clamp(listenSeconds, 5, 60);
         _running = true;
         _startedUtc = DateTime.UtcNow;
 
@@ -130,9 +145,12 @@ public class DxHunterAgent
             _statusLog.Clear();
             _alerts.Clear();
             _alertedCallsigns.Clear();
+            _listenResults.Clear();
+            _listenedAlerts.Clear();
             var bandInfo = string.IsNullOrEmpty(_targetBand) ? "all bands" : _targetBand;
             var modeInfo = string.IsNullOrEmpty(_targetMode) ? "all modes" : _targetMode;
-            LogStatus($"DX Hunter started. Watching {bandInfo}, {modeInfo}. AutoTune={autoTune}.");
+            var listenInfo = autoTune && _cwPipeline != null ? $", Listen={_listenDurationSeconds}s" : "";
+            LogStatus($"DX Hunter started. Watching {bandInfo}, {modeInfo}. AutoTune={autoTune}{listenInfo}.");
         }
 
         // Immediate scan
@@ -172,7 +190,19 @@ public class DxHunterAgent
                 AutoTune: _autoTune,
                 Alerts: _alerts.OrderByDescending(a => a.DetectedUtc).Take(20).ToList(),
                 TotalAlerts: _alerts.Count,
+                ListenResults: _listenResults.OrderByDescending(r => r.ListenedUtc).Take(10).ToList(),
                 StatusLog: _statusLog.ToList());
+        }
+    }
+
+    /// <summary>
+    /// Get recent listen results from active hunting.
+    /// </summary>
+    public List<ListenResult> GetListenResults()
+    {
+        lock (_lock)
+        {
+            return _listenResults.OrderByDescending(r => r.ListenedUtc).ToList();
         }
     }
 
@@ -263,17 +293,74 @@ public class DxHunterAgent
     {
         while (_running)
         {
-            Thread.Sleep(PollIntervalMs);
-            if (!_running) break;
-
             try
             {
+                // Scan for new spots/needs
                 ScanSpots();
+
+                // If autoTune, cycle through alerts and listen to each one
+                if (_autoTune && _running)
+                {
+                    var next = GetNextUnlistenedAlert();
+                    if (next != null)
+                    {
+                        TuneAndListen(next);
+                    }
+                    else
+                    {
+                        // All alerts listened to — wait for new spots
+                        Thread.Sleep(PollIntervalMs);
+                    }
+                }
+                else
+                {
+                    Thread.Sleep(PollIntervalMs);
+                }
             }
             catch (Exception ex)
             {
                 lock (_lock) { LogStatus($"Error: {ex.Message}"); }
+                Thread.Sleep(PollIntervalMs);
             }
+
+            if (!_running) break;
+        }
+    }
+
+    // Band priority order for cycling (lower bands first, best propagation windows)
+    private static readonly string[] BandOrder =
+        ["160m", "80m", "60m", "40m", "30m", "20m", "17m", "15m", "12m", "10m", "6m"];
+
+    private static int BandSortKey(string band)
+    {
+        var idx = Array.IndexOf(BandOrder, band);
+        return idx >= 0 ? idx : 999;
+    }
+
+    private DxAlert? GetNextUnlistenedAlert()
+    {
+        lock (_lock)
+        {
+            if (_alerts.Count == 0) return null;
+
+            // Group by band, prioritize current band first to minimize tuning,
+            // then sort remaining bands in order
+            var unlistened = _alerts
+                .Where(a => !_listenedAlerts.Contains($"{a.Callsign}|{a.Band}"))
+                .OrderBy(a => a.Band.Equals(_currentBand, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .ThenBy(a => BandSortKey(a.Band))
+                .ThenByDescending(a => a.Priority)
+                .FirstOrDefault();
+
+            if (unlistened != null)
+            {
+                _listenedAlerts.Add($"{unlistened.Callsign}|{unlistened.Band}");
+                return unlistened;
+            }
+
+            // All listened — reset and start over
+            _listenedAlerts.Clear();
+            return null; // pause one cycle before restarting
         }
     }
 
@@ -298,16 +385,27 @@ public class DxHunterAgent
             var band = BandScout.BandScoutMonitor.FrequencyToBand(freq);
             if (band == "OOB") continue;
 
+            // Skip FT8/FT4 spots — we can't decode those
+            if (IsFt8Frequency(freq) || IsFt8Mode(mode, comment)) continue;
+
             // Filter by target band/mode
             if (!string.IsNullOrEmpty(_targetBand) &&
                 !band.Equals(_targetBand, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            // If a target mode is set, exclude spots with missing or non-matching mode
-            if (!string.IsNullOrEmpty(_targetMode) &&
-                (string.IsNullOrEmpty(mode) ||
-                 !mode.Equals(_targetMode, StringComparison.OrdinalIgnoreCase)))
-                continue;
+            // If a target mode is set, check mode field AND comment for mode keywords
+            if (!string.IsNullOrEmpty(_targetMode))
+            {
+                bool modeMatch = (!string.IsNullOrEmpty(mode) &&
+                    mode.Equals(_targetMode, StringComparison.OrdinalIgnoreCase));
+                // Also check comment for mode keywords (cluster spots often put mode in comment)
+                if (!modeMatch && !string.IsNullOrEmpty(comment))
+                    modeMatch = comment.Contains(_targetMode, StringComparison.OrdinalIgnoreCase);
+                // Also infer CW from frequency (below x.060 on most bands is CW)
+                if (!modeMatch && _targetMode.Equals("CW", StringComparison.OrdinalIgnoreCase))
+                    modeMatch = IsCwFrequency(freq);
+                if (!modeMatch) continue;
+            }
 
             var entity = DxccLookup.GetEntity(callsign);
             if (entity == "Unknown") continue;
@@ -359,13 +457,211 @@ public class DxHunterAgent
             {
                 LogStatus($"Found {newNeeds} new needs! Total alerts: {_alerts.Count}");
             }
+        }
+    }
 
-            // Auto-tune to highest priority if enabled
-            if (_autoTune && newNeeds > 0)
+    /// <summary>
+    /// Tune to a specific DX alert and listen with the appropriate decoder (CW or SSB).
+    /// </summary>
+    private void TuneAndListen(DxAlert best)
+    {
+        // Check if we're changing bands — need TUNE
+        var spotBand = BandScout.BandScoutMonitor.FrequencyToBand(best.FrequencyMHz);
+        bool bandChanged = !string.IsNullOrEmpty(_currentBand) &&
+                           !spotBand.Equals(_currentBand, StringComparison.OrdinalIgnoreCase) &&
+                           spotBand != "OOB";
+
+        // Tune to the spot
+        var (success, message) = _radioManager.TuneToSpot(best.Callsign);
+        if (!success)
+        {
+            lock (_lock) { LogStatus($"AutoTune failed for {best.Callsign}: {message}"); }
+            return;
+        }
+
+        // Set the correct mode for this spot
+        bool isCw = IsCwSpot(best);
+        if (isCw)
+        {
+            _radioManager.SetMode("CW");
+        }
+        else
+        {
+            // SSB: USB above 10 MHz, LSB below (ham convention)
+            _radioManager.SetMode(best.FrequencyMHz >= 10.0 ? "USB" : "LSB");
+        }
+
+        // TUNE carrier if band changed — keys TX at 5W, watches SWR until it stabilizes
+        if (bandChanged && spotBand != "OOB")
+        {
+            lock (_lock) { LogStatus($"Band change: {_currentBand} → {spotBand} — TUNE at 5W..."); }
+            _currentBand = spotBand;
+
+            // Set tune power to 5W, then key the TUNE carrier
+            _radioManager.SetRfPower(rfPower: null, tunePower: 5);
+            _radioManager.SetTx(mox: null, txTune: true, txMonitor: null, txInhibit: null);
+
+            // Wait for SWR to stabilize (< 2.0) or timeout at 10s
+            var tuneResult = WaitForSwrStable(maxWaitMs: 10_000, targetSwr: 2.0, stableReadings: 3);
+
+            if (!_running)
             {
-                var msg = TuneToNext();
-                lock (_lock) { LogStatus($"AutoTune: {msg}"); }
+                _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
+                return;
             }
+
+            // Stop TUNE
+            _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
+            Thread.Sleep(300); // brief settle time
+            lock (_lock) { LogStatus(tuneResult); }
+        }
+        else if (spotBand != "OOB")
+        {
+            _currentBand = spotBand;
+        }
+
+        string decodeMode = isCw ? "CW" : "SSB";
+
+        lock (_lock)
+        {
+            LogStatus($"Tuned to {best.Callsign} ({best.Entity}) on {best.Band} at {best.FrequencyMHz:F3} MHz — {decodeMode} listening for {_listenDurationSeconds}s...");
+        }
+
+        if (isCw)
+            ListenCw(best);
+        else
+            ListenSsb(best);
+    }
+
+    private bool IsCwSpot(DxAlert alert)
+    {
+        // Check explicit mode
+        if (!string.IsNullOrEmpty(alert.Mode))
+        {
+            if (alert.Mode.Equals("CW", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (alert.Mode.Equals("SSB", StringComparison.OrdinalIgnoreCase) ||
+                alert.Mode.Equals("LSB", StringComparison.OrdinalIgnoreCase) ||
+                alert.Mode.Equals("USB", StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+        // Check comment for mode hints
+        if (!string.IsNullOrEmpty(alert.Comment))
+        {
+            if (alert.Comment.Contains("CW", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (alert.Comment.Contains("SSB", StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+        // Infer from frequency
+        return IsCwFrequency(alert.FrequencyMHz);
+    }
+
+    private void ListenCw(DxAlert spot)
+    {
+        if (_cwPipeline == null)
+        {
+            lock (_lock) { LogStatus($"No CW decoder available for {spot.Callsign}"); }
+            return;
+        }
+
+        _cwPipeline.ClearLiveText();
+        bool weStartedCw = false;
+        if (!_cwPipeline.IsRunning)
+        {
+            _cwPipeline.Start();
+            weStartedCw = true;
+        }
+
+        Thread.Sleep(_listenDurationSeconds * 1000);
+        if (!_running) return;
+
+        var rawText = _cwPipeline.GetLiveText();
+        var chars = _cwPipeline.GetRecentCharacters();
+
+        string correctedText = rawText;
+        bool aiApplied = false;
+        if (_aiRescorer != null && !string.IsNullOrWhiteSpace(rawText) && rawText.Trim().Length >= 3)
+        {
+            try
+            {
+                var result = _aiRescorer.RescoreAsync(rawText, chars).GetAwaiter().GetResult();
+                if (result.AiApplied)
+                {
+                    correctedText = result.CorrectedText;
+                    aiApplied = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (_lock) { LogStatus($"AI rescore error: {ex.Message}"); }
+            }
+        }
+
+        RecordListenResult(spot, "CW", rawText, correctedText, aiApplied);
+
+        if (weStartedCw)
+            _cwPipeline.Stop();
+    }
+
+    private void ListenSsb(DxAlert spot)
+    {
+        if (_ssbPipeline == null)
+        {
+            lock (_lock) { LogStatus($"No SSB decoder available for {spot.Callsign}"); }
+            return;
+        }
+
+        _ssbPipeline.ClearLiveText();
+        bool weStartedSsb = false;
+        if (!_ssbPipeline.IsRunning)
+        {
+            var startResult = _ssbPipeline.Start();
+            if (startResult != "ok")
+            {
+                lock (_lock) { LogStatus($"SSB start failed for {spot.Callsign}: {startResult}"); }
+                return;
+            }
+            weStartedSsb = true;
+        }
+
+        Thread.Sleep(_listenDurationSeconds * 1000);
+        if (!_running) return;
+
+        var rawText = _ssbPipeline.GetLiveText();
+        bool signalHeard = !string.IsNullOrWhiteSpace(rawText) && rawText != "(no speech detected)";
+
+        RecordListenResult(spot, "SSB", signalHeard ? rawText : "", rawText, false);
+
+        if (weStartedSsb)
+            _ssbPipeline.Stop();
+    }
+
+    private void RecordListenResult(DxAlert spot, string decodeMode, string rawText, string correctedText, bool aiApplied)
+    {
+        var listenResult = new ListenResult(
+            Callsign: spot.Callsign,
+            Entity: spot.Entity,
+            Band: spot.Band,
+            FrequencyMHz: spot.FrequencyMHz,
+            DecodeMode: decodeMode,
+            RawDecode: rawText,
+            AiCorrected: correctedText,
+            AiApplied: aiApplied,
+            ListenDurationSeconds: _listenDurationSeconds,
+            SignalHeard: !string.IsNullOrWhiteSpace(rawText) && rawText != "(no speech detected)",
+            ListenedUtc: DateTime.UtcNow);
+
+        lock (_lock)
+        {
+            _listenResults.Add(listenResult);
+            if (_listenResults.Count > MaxListenResults)
+                _listenResults.RemoveAt(0);
+
+            if (listenResult.SignalHeard)
+                LogStatus($"HEARD [{decodeMode}] {spot.Callsign}: \"{correctedText.Trim()}\"");
+            else
+                LogStatus($"No signal [{decodeMode}] on {spot.Callsign} ({spot.FrequencyMHz:F3} MHz)");
         }
     }
 
@@ -377,6 +673,97 @@ public class DxHunterAgent
             _statusLog.RemoveAt(0);
         Console.Error.WriteLine($"[DXHUNTER] {message}");
     }
+
+    /// <summary>
+    /// Poll SWR meter during TUNE and return once it stabilizes below target or times out.
+    /// </summary>
+    private string WaitForSwrStable(int maxWaitMs, double targetSwr, int stableReadings)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int goodCount = 0;
+        double lastSwr = 99.0;
+
+        // Give the tuner a moment to start
+        Thread.Sleep(500);
+
+        while (sw.ElapsedMilliseconds < maxWaitMs && _running)
+        {
+            var meters = _radioManager.GetMeters();
+            if (meters.TryGetValue("SWR", out var swrObj) && swrObj is double swr && swr > 0)
+            {
+                lastSwr = swr;
+                if (swr <= targetSwr)
+                {
+                    goodCount++;
+                    if (goodCount >= stableReadings)
+                    {
+                        return $"TUNE done in {sw.ElapsedMilliseconds / 1000.0:F1}s — SWR {swr:F1}:1";
+                    }
+                }
+                else
+                {
+                    goodCount = 0; // reset if SWR goes back up
+                }
+            }
+
+            Thread.Sleep(250); // poll every 250ms
+        }
+
+        return $"TUNE timeout ({maxWaitMs / 1000}s) — SWR {lastSwr:F1}:1";
+    }
+
+    /// <summary>
+    /// Detect FT8/FT4 from mode or comment fields.
+    /// </summary>
+    private static bool IsFt8Mode(string mode, string comment)
+    {
+        if (!string.IsNullOrEmpty(mode))
+        {
+            if (mode.Equals("FT8", StringComparison.OrdinalIgnoreCase) ||
+                mode.Equals("FT4", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        if (!string.IsNullOrEmpty(comment))
+        {
+            if (comment.Contains("FT8", StringComparison.OrdinalIgnoreCase) ||
+                comment.Contains("FT4", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Detect FT8/FT4 from standard dial frequencies.
+    /// </summary>
+    private static bool IsFt8Frequency(double mhz)
+    {
+        // FT8 standard dial frequencies (±2 kHz window)
+        ReadOnlySpan<double> ft8Freqs = [1.840, 3.573, 5.357, 7.074, 10.136, 14.074,
+                                          18.100, 21.074, 24.915, 28.074, 50.313, 50.323];
+        foreach (var f in ft8Freqs)
+        {
+            if (Math.Abs(mhz - f) < 0.003) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Infer CW mode from frequency — below the CW/digital boundary on each band.
+    /// </summary>
+    private static bool IsCwFrequency(double mhz) => mhz switch
+    {
+        >= 1.800 and < 1.840 => true,
+        >= 3.500 and < 3.570 => true,
+        >= 5.330 and < 5.360 => true,
+        >= 7.000 and < 7.060 => true,
+        >= 10.100 and < 10.130 => true,
+        >= 14.000 and < 14.070 => true,
+        >= 18.068 and < 18.095 => true,
+        >= 21.000 and < 21.070 => true,
+        >= 24.890 and < 24.920 => true,
+        >= 28.000 and < 28.070 => true,
+        _ => false
+    };
 }
 
 // --- Records ---
@@ -392,7 +779,21 @@ public record DxHunterState(
     bool AutoTune,
     List<DxAlert> Alerts,
     int TotalAlerts,
+    List<ListenResult> ListenResults,
     List<string> StatusLog);
+
+public record ListenResult(
+    string Callsign,
+    string Entity,
+    string Band,
+    double FrequencyMHz,
+    string DecodeMode,
+    string RawDecode,
+    string AiCorrected,
+    bool AiApplied,
+    int ListenDurationSeconds,
+    bool SignalHeard,
+    DateTime ListenedUtc);
 
 public record DxAlert(
     string Callsign,

--- a/src/SmartSdrMcp.DxHunter/DxHunterAgent.cs
+++ b/src/SmartSdrMcp.DxHunter/DxHunterAgent.cs
@@ -3,6 +3,7 @@ using SmartSdrMcp.BandScout;
 using SmartSdrMcp.Cw;
 using SmartSdrMcp.Radio;
 using SmartSdrMcp.Ssb;
+using SmartSdrMcp.Tx;
 
 namespace SmartSdrMcp.DxHunter;
 
@@ -12,6 +13,7 @@ public class DxHunterAgent
     private readonly CwPipeline? _cwPipeline;
     private readonly CwAiRescorer? _aiRescorer;
     private readonly SsbPipeline? _ssbPipeline;
+    private readonly TransmitController? _txController;
     private readonly object _lock = new();
     private readonly List<string> _statusLog = new();
     private readonly List<ListenResult> _listenResults = new();
@@ -42,12 +44,13 @@ public class DxHunterAgent
 
     public bool IsRunning => _running;
 
-    public DxHunterAgent(RadioManager radioManager, CwPipeline? cwPipeline = null, CwAiRescorer? aiRescorer = null, SsbPipeline? ssbPipeline = null)
+    public DxHunterAgent(RadioManager radioManager, CwPipeline? cwPipeline = null, CwAiRescorer? aiRescorer = null, SsbPipeline? ssbPipeline = null, TransmitController? txController = null)
     {
         _radioManager = radioManager;
         _cwPipeline = cwPipeline;
         _aiRescorer = aiRescorer;
         _ssbPipeline = ssbPipeline;
+        _txController = txController;
     }
 
     // Allowed file extensions for log files
@@ -494,26 +497,46 @@ public class DxHunterAgent
         // TUNE carrier if band changed — keys TX at 5W, watches SWR until it stabilizes
         if (bandChanged && spotBand != "OOB")
         {
-            lock (_lock) { LogStatus($"Band change: {_currentBand} → {spotBand} — TUNE at 5W..."); }
-            _currentBand = spotBand;
-
-            // Set tune power to 5W, then key the TUNE carrier
-            _radioManager.SetRfPower(rfPower: null, tunePower: 5);
-            _radioManager.SetTx(mox: null, txTune: true, txMonitor: null, txInhibit: null);
-
-            // Wait for SWR to stabilize (< 2.0) or timeout at 10s
-            var tuneResult = WaitForSwrStable(maxWaitMs: 10_000, targetSwr: 2.0, stableReadings: 3);
-
-            if (!_running)
+            // Check TX guard — don't transmit if inhibited
+            var txGuard = _txController?.GetTxGuardState();
+            if (txGuard != null && !txGuard.Armed)
             {
-                _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
-                return;
+                lock (_lock) { LogStatus($"Band change: {_currentBand} → {spotBand} — TX inhibited, skipping TUNE."); }
+                _currentBand = spotBand;
             }
+            else
+            {
+                lock (_lock) { LogStatus($"Band change: {_currentBand} → {spotBand} — TUNE at 5W..."); }
+                _currentBand = spotBand;
 
-            // Stop TUNE
-            _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
-            Thread.Sleep(300); // brief settle time
-            lock (_lock) { LogStatus(tuneResult); }
+                // Save prior tune power to restore after
+                int? priorTunePower = null;
+                var rfState = _radioManager.GetRfPower();
+                if (rfState != null)
+                {
+                    var tpProp = rfState.GetType().GetProperty("TunePower");
+                    if (tpProp?.GetValue(rfState) is int tp) priorTunePower = tp;
+                }
+
+                // Set tune power to 5W, then key the TUNE carrier
+                _radioManager.SetRfPower(rfPower: null, tunePower: 5);
+                _radioManager.SetTx(mox: null, txTune: true, txMonitor: null, txInhibit: null);
+
+                // Wait for SWR to stabilize (< 2.0) or timeout at 10s
+                var tuneResult = WaitForSwrStable(maxWaitMs: 10_000, targetSwr: 2.0, stableReadings: 3);
+
+                // Stop TUNE
+                _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
+
+                // Restore prior tune power
+                if (priorTunePower.HasValue)
+                    _radioManager.SetRfPower(rfPower: null, tunePower: priorTunePower.Value);
+
+                if (!_running) return;
+
+                Thread.Sleep(300); // brief settle time
+                lock (_lock) { LogStatus(tuneResult); }
+            }
         }
         else if (spotBand != "OOB")
         {
@@ -585,11 +608,22 @@ public class DxHunterAgent
         {
             try
             {
-                var result = _aiRescorer.RescoreAsync(rawText, chars).GetAwaiter().GetResult();
-                if (result.AiApplied)
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var rescoreTask = _aiRescorer.RescoreAsync(rawText, chars);
+                var completed = Task.WhenAny(rescoreTask, Task.Delay(10_000, cts.Token)).GetAwaiter().GetResult();
+                if (completed == rescoreTask)
                 {
-                    correctedText = result.CorrectedText;
-                    aiApplied = true;
+                    cts.Cancel();
+                    var result = rescoreTask.GetAwaiter().GetResult();
+                    if (result.AiApplied)
+                    {
+                        correctedText = result.CorrectedText;
+                        aiApplied = true;
+                    }
+                }
+                else
+                {
+                    lock (_lock) { LogStatus($"AI rescore timeout for {spot.Callsign}, skipping"); }
                 }
             }
             catch (Exception ex)

--- a/src/SmartSdrMcp.DxHunter/SmartSdrMcp.DxHunter.csproj
+++ b/src/SmartSdrMcp.DxHunter/SmartSdrMcp.DxHunter.csproj
@@ -6,6 +6,7 @@
     <ProjectReference Include="..\SmartSdrMcp.Cw\SmartSdrMcp.Cw.csproj" />
     <ProjectReference Include="..\SmartSdrMcp.Ai\SmartSdrMcp.Ai.csproj" />
     <ProjectReference Include="..\SmartSdrMcp.Ssb\SmartSdrMcp.Ssb.csproj" />
+    <ProjectReference Include="..\SmartSdrMcp.Tx\SmartSdrMcp.Tx.csproj" />
     <ProjectReference Include="..\..\lib\FlexLib_Core\FlexLib\FlexLib.csproj" />
   </ItemGroup>
 

--- a/src/SmartSdrMcp.DxHunter/SmartSdrMcp.DxHunter.csproj
+++ b/src/SmartSdrMcp.DxHunter/SmartSdrMcp.DxHunter.csproj
@@ -3,6 +3,9 @@
   <ItemGroup>
     <ProjectReference Include="..\SmartSdrMcp.Radio\SmartSdrMcp.Radio.csproj" />
     <ProjectReference Include="..\SmartSdrMcp.BandScout\SmartSdrMcp.BandScout.csproj" />
+    <ProjectReference Include="..\SmartSdrMcp.Cw\SmartSdrMcp.Cw.csproj" />
+    <ProjectReference Include="..\SmartSdrMcp.Ai\SmartSdrMcp.Ai.csproj" />
+    <ProjectReference Include="..\SmartSdrMcp.Ssb\SmartSdrMcp.Ssb.csproj" />
     <ProjectReference Include="..\..\lib\FlexLib_Core\FlexLib\FlexLib.csproj" />
   </ItemGroup>
 

--- a/src/SmartSdrMcp.Mcp/Tools/CwListenerTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/CwListenerTools.cs
@@ -19,7 +19,7 @@ public class CwListenerTools
     private readonly CwPipeline _cwPipeline;
     private readonly MessageSegmenter _messageSegmenter;
     private readonly QsoTracker _qsoTracker;
-    private readonly CwAiRescorer _aiRescorer;
+    private readonly CwAiRescorer? _aiRescorer;
 
     public CwListenerTools(
         RadioManager radioManager,
@@ -27,7 +27,7 @@ public class CwListenerTools
         CwPipeline cwPipeline,
         MessageSegmenter messageSegmenter,
         QsoTracker qsoTracker,
-        CwAiRescorer aiRescorer)
+        CwAiRescorer? aiRescorer = null)
     {
         _radioManager = radioManager;
         _audioPipeline = audioPipeline;
@@ -168,6 +168,9 @@ public class CwListenerTools
     [McpServerTool, Description("AI-rescore the current CW decode buffer. Uses Claude to correct dit/dah confusions and apply ham radio context. Requires ANTHROPIC_API_KEY environment variable.")]
     public async Task<string> CwAiRescore()
     {
+        if (_aiRescorer == null)
+            return "AI rescoring is not available. Set the ANTHROPIC_API_KEY environment variable to enable it.";
+
         if (!_cwPipeline.IsRunning)
             return "CW listener is not running.";
 

--- a/src/SmartSdrMcp.Mcp/Tools/CwListenerTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/CwListenerTools.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using ModelContextProtocol.Server;
+using SmartSdrMcp.Ai;
 using SmartSdrMcp.Audio;
 using SmartSdrMcp.Cw;
 using SmartSdrMcp.Qso;
@@ -18,19 +19,22 @@ public class CwListenerTools
     private readonly CwPipeline _cwPipeline;
     private readonly MessageSegmenter _messageSegmenter;
     private readonly QsoTracker _qsoTracker;
+    private readonly CwAiRescorer _aiRescorer;
 
     public CwListenerTools(
         RadioManager radioManager,
         AudioPipeline audioPipeline,
         CwPipeline cwPipeline,
         MessageSegmenter messageSegmenter,
-        QsoTracker qsoTracker)
+        QsoTracker qsoTracker,
+        CwAiRescorer aiRescorer)
     {
         _radioManager = radioManager;
         _audioPipeline = audioPipeline;
         _cwPipeline = cwPipeline;
         _messageSegmenter = messageSegmenter;
         _qsoTracker = qsoTracker;
+        _aiRescorer = aiRescorer;
     }
 
     [McpServerTool, Description("Start continuous CW listening on the current slice. Captures DAX audio, decodes Morse code, and tracks QSO state. Set fixedWpm to lock decoder speed (0 = auto-detect).")]
@@ -159,6 +163,61 @@ public class CwListenerTools
             info.StartedUtc,
             info.EndedUtc
         }, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool, Description("AI-rescore the current CW decode buffer. Uses Claude to correct dit/dah confusions and apply ham radio context. Requires ANTHROPIC_API_KEY environment variable.")]
+    public async Task<string> CwAiRescore()
+    {
+        if (!_cwPipeline.IsRunning)
+            return "CW listener is not running.";
+
+        var rawText = _cwPipeline.GetLiveText();
+        if (string.IsNullOrWhiteSpace(rawText))
+            return "No CW text to rescore.";
+
+        var characters = _cwPipeline.GetRecentCharacters();
+        var result = await _aiRescorer.RescoreAsync(rawText, characters);
+
+        if (!result.AiApplied)
+            return $"AI rescoring failed: {result.Error}\nOriginal: {result.OriginalText}";
+
+        return $"Original:  {result.OriginalText}\nCorrected: {result.CorrectedText}";
+    }
+
+    [McpServerTool, Description("Get N-best character alternatives for the current CW decode. Shows ambiguous characters with their alternative interpretations and confidence scores.")]
+    public string CwGetAlternatives()
+    {
+        if (!_cwPipeline.IsRunning)
+            return "CW listener is not running.";
+
+        var characters = _cwPipeline.GetRecentCharacters();
+        if (characters.Count == 0)
+            return "No decoded characters yet.";
+
+        var ambiguous = characters
+            .Select((c, i) => new { c, i })
+            .Where(x => x.c.Alternatives is { Count: > 0 })
+            .Select(x => new
+            {
+                Position = x.i,
+                x.c.Character,
+                Pattern = x.c.DitDahPattern,
+                x.c.Confidence,
+                Alternatives = x.c.Alternatives!.Select(a => new
+                {
+                    a.Character,
+                    a.DitDahPattern,
+                    a.Score
+                })
+            })
+            .ToList();
+
+        if (ambiguous.Count == 0)
+            return "No ambiguous characters — all decodes were high confidence.";
+
+        var text = _cwPipeline.GetLiveText();
+        var result = new { DecodedText = text, AmbiguousCount = ambiguous.Count, Total = characters.Count, Ambiguous = ambiguous };
+        return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
     }
 
     [McpServerTool, Description("Export current/recent QSO data. Formats: json or adif.")]

--- a/src/SmartSdrMcp.Mcp/Tools/DxHunterTools.cs
+++ b/src/SmartSdrMcp.Mcp/Tools/DxHunterTools.cs
@@ -11,6 +11,7 @@ public class DxHunterTools
 {
     private readonly DxHunterAgent _dxHunter;
     private readonly RadioManager _radioManager;
+    private readonly DxClusterService _clusterService;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -18,10 +19,11 @@ public class DxHunterTools
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
     };
 
-    public DxHunterTools(DxHunterAgent dxHunter, RadioManager radioManager)
+    public DxHunterTools(DxHunterAgent dxHunter, RadioManager radioManager, DxClusterService clusterService)
     {
         _dxHunter = dxHunter;
         _radioManager = radioManager;
+        _clusterService = clusterService;
     }
 
     [McpServerTool, Description(
@@ -37,13 +39,15 @@ public class DxHunterTools
         "Start the Auto DX Hunter. Watches incoming DX spots and cross-references each one against your logbook. " +
         "Alerts you when a spotted station is a DXCC entity you haven't worked on that band yet (a 'need'). " +
         "Optionally filter by band (e.g. '20m') and mode (e.g. 'CW'). " +
-        "Set autoTune=true to automatically QSY to the highest priority need when detected.")]
-    public string DxHunterStart(string? band = null, string? mode = null, bool autoTune = false)
+        "Set autoTune=true to automatically QSY to each need, listen with the CW decoder (for CW spots) " +
+        "or SSB speech-to-text (for SSB/phone spots) for listenSeconds, AI-rescore if CW, " +
+        "and report what was heard. This creates an active DX hunting loop.")]
+    public string DxHunterStart(string? band = null, string? mode = null, bool autoTune = false, int listenSeconds = 15)
     {
         if (!_radioManager.IsConnected)
             return "Not connected to a radio. Call connect_radio first.";
 
-        return _dxHunter.Start(band, mode, autoTune);
+        return _dxHunter.Start(band, mode, autoTune, listenSeconds);
     }
 
     [McpServerTool, Description("Stop the Auto DX Hunter.")]
@@ -106,5 +110,44 @@ public class DxHunterTools
     {
         var entity = DxccLookup.GetEntity(callsign);
         return $"{callsign.ToUpperInvariant()} → {entity}";
+    }
+
+    [McpServerTool, Description(
+        "Get results from the DX Hunter's active listening sessions. When autoTune is enabled, " +
+        "the hunter tunes to each DX need and listens with the CW decoder + AI rescorer. " +
+        "This returns what was heard on each frequency — raw decode and AI-corrected text.")]
+    public string DxHunterListenResults()
+    {
+        var results = _dxHunter.GetListenResults();
+        if (results.Count == 0)
+            return "No listen results yet. Start the DX Hunter with autoTune=true to begin active hunting.";
+
+        return JsonSerializer.Serialize(results, JsonOptions);
+    }
+
+    // --- DX Cluster Feed ---
+
+    [McpServerTool, Description(
+        "Start the DX Cluster spot feed. Fetches DX spots from HamQTH and pushes them to the radio's panadapter. " +
+        "Spots appear as colored markers — blue for normal spots, RED for DX needs (entities you haven't worked). " +
+        "Optionally filter by band (e.g. '20m') and mode (e.g. 'CW'). Poll interval in seconds (default 30, minimum 15).")]
+    public string DxClusterStart(string? band = null, string? mode = null, int pollSeconds = 30)
+    {
+        if (!_radioManager.IsConnected)
+            return "Not connected to a radio. Call connect_radio first.";
+
+        return _clusterService.Start(band, mode, pollSeconds);
+    }
+
+    [McpServerTool, Description("Stop the DX Cluster spot feed and stop pushing spots to the panadapter.")]
+    public string DxClusterStop()
+    {
+        return _clusterService.Stop();
+    }
+
+    [McpServerTool, Description("Get DX Cluster feed status including spots pushed and recent log entries.")]
+    public string DxClusterStatus()
+    {
+        return JsonSerializer.Serialize(_clusterService.GetStatus(), JsonOptions);
     }
 }

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -792,6 +792,9 @@ public class RadioManager : IDisposable
     {
         var radio = _radio;
         if (radio == null || !radio.Connected) return false;
+        if (string.IsNullOrWhiteSpace(callsign)) return false;
+        if (frequencyMHz <= 0) return false;
+        lifetimeSeconds = Math.Clamp(lifetimeSeconds, 0, 86400); // cap at 24h
 
         var spot = new Flex.Smoothlake.FlexLib.Spot
         {

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -783,6 +783,42 @@ public class RadioManager : IDisposable
         return true;
     }
 
+    // --- Add Spot (#30) ---
+
+    public bool AddSpot(string callsign, double frequencyMHz, string? mode = null,
+        string? color = null, string? backgroundColor = null,
+        string? spotterCallsign = null, string? source = null,
+        string? comment = null, int lifetimeSeconds = 600)
+    {
+        var radio = _radio;
+        if (radio == null || !radio.Connected) return false;
+
+        var spot = new Flex.Smoothlake.FlexLib.Spot
+        {
+            Callsign = callsign,
+            RXFrequency = frequencyMHz,
+            LifetimeSeconds = lifetimeSeconds
+        };
+
+        if (mode != null) spot.Mode = mode;
+        if (color != null) spot.Color = color;
+        if (backgroundColor != null) spot.BackgroundColor = backgroundColor;
+        if (spotterCallsign != null) spot.SpotterCallsign = spotterCallsign;
+        if (source != null) spot.Source = source;
+        if (comment != null) spot.Comment = comment;
+        spot.Timestamp = DateTime.UtcNow;
+
+        radio.RequestSpot(spot);
+        return true;
+    }
+
+    public void ClearAllSpots()
+    {
+        var radio = _radio;
+        if (radio == null || !radio.Connected) return;
+        radio.ClearAllSpots();
+    }
+
     // --- Tune to Spot (#29) ---
 
     public (bool Success, string Message) TuneToSpot(string callsign)

--- a/src/SmartSdrMcp.Radio/RadioManager.cs
+++ b/src/SmartSdrMcp.Radio/RadioManager.cs
@@ -395,6 +395,12 @@ public class RadioManager : IDisposable
         };
     }
 
+    public int? GetTunePower()
+    {
+        var radio = _radio;
+        return radio?.Connected == true ? radio.TunePower : null;
+    }
+
     public bool SetRfPower(int? rfPower, int? tunePower)
     {
         var radio = _radio;
@@ -785,6 +791,11 @@ public class RadioManager : IDisposable
 
     // --- Add Spot (#30) ---
 
+    // Validates "#AARRGGBB" hex color format expected by FlexRadio spot API
+    private static bool IsValidArgbColor(string color) =>
+        color.Length == 9 && color[0] == '#' &&
+        color[1..].All(Uri.IsHexDigit);
+
     public bool AddSpot(string callsign, double frequencyMHz, string? mode = null,
         string? color = null, string? backgroundColor = null,
         string? spotterCallsign = null, string? source = null,
@@ -794,6 +805,8 @@ public class RadioManager : IDisposable
         if (radio == null || !radio.Connected) return false;
         if (string.IsNullOrWhiteSpace(callsign)) return false;
         if (frequencyMHz <= 0) return false;
+        if (color != null && !IsValidArgbColor(color)) return false;
+        if (backgroundColor != null && !IsValidArgbColor(backgroundColor)) return false;
         lifetimeSeconds = Math.Clamp(lifetimeSeconds, 0, 86400); // cap at 24h
 
         var spot = new Flex.Smoothlake.FlexLib.Spot

--- a/src/SmartSdrMcp.Tx/TransmitController.cs
+++ b/src/SmartSdrMcp.Tx/TransmitController.cs
@@ -160,6 +160,35 @@ public class TransmitController
         }
     }
 
+    /// <summary>
+    /// Key a TUNE carrier through the TX safety layer.
+    /// Checks guard Armed state and band-edge safety before keying.
+    /// </summary>
+    public (bool Success, string Message) TxTune(int tunePower = 5)
+    {
+        var guard = GetTxGuardState();
+        if (!guard.Armed)
+            return (false, "TX guard blocked TUNE: set armed=true via set_tx_guard first.");
+
+        var state = _radioManager.GetState();
+        var freqCheck = _safety.CheckTransmitAllowed(state.FrequencyMHz);
+        if (!freqCheck.Allowed)
+            return (false, freqCheck.Reason!);
+
+        _radioManager.SetRfPower(rfPower: null, tunePower: tunePower);
+        _radioManager.SetTx(mox: null, txTune: true, txMonitor: null, txInhibit: null);
+        TransmitStarted?.Invoke($"TUNE at {tunePower}W");
+        return (true, $"TUNE keyed at {tunePower}W");
+    }
+
+    /// <summary>Stop a running TUNE carrier.</summary>
+    public (bool Success, string Message) TxTuneStop()
+    {
+        _radioManager.SetTx(mox: null, txTune: false, txMonitor: null, txInhibit: null);
+        TransmitCompleted?.Invoke();
+        return (true, "TUNE stopped");
+    }
+
     public (bool Success, string Message) Abort()
     {
         var radio = _radioManager.Radio;

--- a/src/SmartSdrMcp/Program.cs
+++ b/src/SmartSdrMcp/Program.cs
@@ -41,11 +41,12 @@ builder.Services.AddSingleton<QsoTracker>(sp =>
 });
 builder.Services.AddSingleton<ReplyGenerator>(_ =>
     new ReplyGenerator(MyCallsign, MyName));
-builder.Services.AddSingleton<CwAiRescorer>(sp =>
+builder.Services.AddSingleton<CwAiRescorer?>(sp =>
 {
-    var httpClient = new HttpClient();
-    var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")
-        ?? throw new InvalidOperationException("ANTHROPIC_API_KEY environment variable is required for CW AI rescoring.");
+    var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+    if (string.IsNullOrWhiteSpace(apiKey))
+        return null; // AI rescoring disabled — server still works without it
+    var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
     CwAiRescorer.ConfigureHttpClient(httpClient, apiKey);
     return new CwAiRescorer(httpClient);
 });
@@ -70,8 +71,9 @@ builder.Services.AddSingleton<DxHunterAgent>(sp =>
     new DxHunterAgent(
         sp.GetRequiredService<RadioManager>(),
         sp.GetRequiredService<CwPipeline>(),
-        sp.GetRequiredService<CwAiRescorer>(),
-        sp.GetRequiredService<SsbPipeline>()));
+        sp.GetService<CwAiRescorer>(),
+        sp.GetRequiredService<SsbPipeline>(),
+        sp.GetRequiredService<TransmitController>()));
 builder.Services.AddSingleton<DxClusterService>(sp =>
     new DxClusterService(
         sp.GetRequiredService<RadioManager>(),

--- a/src/SmartSdrMcp/Program.cs
+++ b/src/SmartSdrMcp/Program.cs
@@ -41,15 +41,16 @@ builder.Services.AddSingleton<QsoTracker>(sp =>
 });
 builder.Services.AddSingleton<ReplyGenerator>(_ =>
     new ReplyGenerator(MyCallsign, MyName));
-builder.Services.AddSingleton<CwAiRescorer?>(sp =>
+var anthropicApiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+if (!string.IsNullOrWhiteSpace(anthropicApiKey))
 {
-    var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-    if (string.IsNullOrWhiteSpace(apiKey))
-        return null; // AI rescoring disabled — server still works without it
-    var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-    CwAiRescorer.ConfigureHttpClient(httpClient, apiKey);
-    return new CwAiRescorer(httpClient);
-});
+    builder.Services.AddSingleton<CwAiRescorer>(sp =>
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        CwAiRescorer.ConfigureHttpClient(client, anthropicApiKey);
+        return new CwAiRescorer(client);
+    });
+}
 builder.Services.AddSingleton<TransmitController>();
 builder.Services.AddSingleton<SsbPipeline>(sp =>
 {

--- a/src/SmartSdrMcp/Program.cs
+++ b/src/SmartSdrMcp/Program.cs
@@ -41,6 +41,14 @@ builder.Services.AddSingleton<QsoTracker>(sp =>
 });
 builder.Services.AddSingleton<ReplyGenerator>(_ =>
     new ReplyGenerator(MyCallsign, MyName));
+builder.Services.AddSingleton<CwAiRescorer>(sp =>
+{
+    var httpClient = new HttpClient();
+    var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")
+        ?? throw new InvalidOperationException("ANTHROPIC_API_KEY environment variable is required for CW AI rescoring.");
+    CwAiRescorer.ConfigureHttpClient(httpClient, apiKey);
+    return new CwAiRescorer(httpClient);
+});
 builder.Services.AddSingleton<TransmitController>();
 builder.Services.AddSingleton<SsbPipeline>(sp =>
 {
@@ -59,7 +67,15 @@ builder.Services.AddSingleton<ContestAgent>(sp =>
 builder.Services.AddSingleton<BandScoutMonitor>(sp =>
     new BandScoutMonitor(sp.GetRequiredService<RadioManager>()));
 builder.Services.AddSingleton<DxHunterAgent>(sp =>
-    new DxHunterAgent(sp.GetRequiredService<RadioManager>()));
+    new DxHunterAgent(
+        sp.GetRequiredService<RadioManager>(),
+        sp.GetRequiredService<CwPipeline>(),
+        sp.GetRequiredService<CwAiRescorer>(),
+        sp.GetRequiredService<SsbPipeline>()));
+builder.Services.AddSingleton<DxClusterService>(sp =>
+    new DxClusterService(
+        sp.GetRequiredService<RadioManager>(),
+        sp.GetRequiredService<DxHunterAgent>()));
 
 // MCP Server
 builder.Services.AddMcpServer()


### PR DESCRIPTION
## Summary
- **Band Scout**: New `SmartSdrMcp.BandScout` project with `BandScoutMonitor` for automated band activity scanning, exposed via MCP tools
- **DX Hunter**: New `SmartSdrMcp.DxHunter` project with `DxHunterAgent`, `DxClusterService`, `AdifParser`, and `DxccLookup` for automated DX spot hunting, ADIF log import, and DXCC entity tracking
- **CW AI Rescorer**: New `CwAiRescorer` in `SmartSdrMcp.Ai` for AI-assisted CW decode correction
- **Radio tools expansion**: Added antenna, slice audio, TX, EQ, mic, VOX, panadapter, and tune-to-spot MCP tools in `RadioManager` and `RadioTools`
- **Security hardening**: Removed hardcoded API key, added TX safety improvements, input validation across tools

## Test plan
- [x] Verify Band Scout start/stop/report tools work with connected radio
- [x] Test DX Hunter agent: start, tune_next, listen_results, mark_worked, stop
- [x] Test DX cluster connect/disconnect and spot streaming
- [x] Verify CW AI rescoring with ANTHROPIC_API_KEY env var set
- [x] Confirm new radio tools (antenna, EQ, mic, VOX, panadapter) function correctly
- [x] Validate ADIF log import and DXCC needs lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)